### PR TITLE
Fix v1.0.0 CI badge: correct SyndiKit.yml casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Swift Package built on top of [XMLCoder](https://github.com/CoreOffice/XMLCoder)
 [![License](https://img.shields.io/github/license/brightdigit/SyndiKit)](LICENSE)
 
 <!-- CI/CD & Code Quality -->
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/brightdigit/SyndiKit/syndikit.yml?label=actions&logo=github&?branch=main)](https://github.com/brightdigit/SyndiKit/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/brightdigit/SyndiKit/SyndiKit.yml?label=actions&logo=github&branch=main)](https://github.com/brightdigit/SyndiKit/actions)
 [![Maintainability](https://qlty.sh/gh/brightdigit/projects/SyndiKit/maintainability.svg)](https://qlty.sh/gh/brightdigit/projects/SyndiKit)
 [![Codecov](https://img.shields.io/codecov/c/github/brightdigit/SyndiKit)](https://codecov.io/gh/brightdigit/SyndiKit)
 [![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/brightdigit/SyndiKit)](https://www.codefactor.io/repository/github/brightdigit/SyndiKit)


### PR DESCRIPTION
The `GitHub Workflow Status` badge on the `v1.0.0` branch pointed at `syndikit.yml` (lowercase), but on `v1.0.0` the workflow file is **`SyndiKit.yml`** (PascalCase) — matching the other Wave 0 repos. As a result the badge rendered "no status" on the exact-case shields.io path.

**Fix (badge only):**
- `syndikit.yml` → `SyndiKit.yml` (case)
- drop the stray `?` in `&?branch=main` → `&branch=main`

No workflow file was renamed — the PascalCase `SyndiKit.yml` is the correct, intended name on this branch; only the README badge was stale (carried over from `main`, where the file is lowercase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)